### PR TITLE
trigger can be string[] or string

### DIFF
--- a/src/OverlayTrigger.d.ts
+++ b/src/OverlayTrigger.d.ts
@@ -23,7 +23,7 @@ export interface OverlayTriggerProps extends React.Props<OverlayTriggerClass> {
   onExiting?: Function;
   placement?: string;
   rootClose?: boolean;
-  trigger?: string;
+  trigger?: string | string[];
 }
 export interface OverlayTrigger extends React.ReactElement<OverlayTriggerProps> { }
 export interface OverlayTriggerClass extends  React.ComponentClass<OverlayTriggerProps> { }


### PR DESCRIPTION
When using OverlayTrigger the trigger property takes both a string or an array of strings for multiple triggers.